### PR TITLE
Added support for Foundry VTT version 9

### DIFF
--- a/Entities.js
+++ b/Entities.js
@@ -161,7 +161,7 @@ class FurnaceSplitJournal extends FormApplication {
             callback: header => {
                 let entityId = header.attr("data-entity-id");
                 // newer versions of foundry does not have "data-entity-id" instead use "data-document-id" as they are equivalent.
-                if(!entityId) entityId = header.attr("data-document-id"); 
+                if(typeof entityId !== "undefined") entityId = header.attr("data-document-id"); 
                 let entity = game.journal.get(entityId);
                 new FurnaceSplitJournal(entity).render(true);
 

--- a/Entities.js
+++ b/Entities.js
@@ -161,7 +161,7 @@ class FurnaceSplitJournal extends FormApplication {
             callback: header => {
                 let entityId = header.attr("data-entity-id");
                 // newer versions of foundry does not have "data-entity-id" instead use "data-document-id" as they are equivalent.
-                if(typeof entityId !== "undefined") entityId = header.attr("data-document-id"); 
+                if(typeof entityId === "undefined") entityId = header.attr("data-document-id"); 
                 let entity = game.journal.get(entityId);
                 new FurnaceSplitJournal(entity).render(true);
 

--- a/Entities.js
+++ b/Entities.js
@@ -160,6 +160,8 @@ class FurnaceSplitJournal extends FormApplication {
             condition: game.user.isGM,
             callback: header => {
                 let entityId = header.attr("data-entity-id");
+                // newer versions of foundry does not have "data-entity-id" instead use "data-document-id" as they are equivalent.
+                if(!entityId) entityId = header.attr("data-document-id"); 
                 let entity = game.journal.get(entityId);
                 new FurnaceSplitJournal(entity).render(true);
 

--- a/module.json
+++ b/module.json
@@ -6,9 +6,9 @@
   "authors": [],
   "url": "https://github.com/League-of-Foundry-Developers/fvtt-split-journal",
   "flags": {},
-  "version": "1.0.0",
+  "version": "1.2.0",
   "minimumCoreVersion": "0.8.4",
-  "compatibleCoreVersion": "0.8.6",
+  "compatibleCoreVersion": "0.9",
   "scripts": [
     "libs/split-html.js",
     "Entities.js"


### PR DESCRIPTION
I added a fallback incase the attribute "data-entity-id" was not found to look at attribute "data-document-id".

I still need to test this with older versions of Foundry and on other computers than my own.

Should resolve issue #5 